### PR TITLE
Fix fn highlight and toml comments

### DIFF
--- a/config/toml.json
+++ b/config/toml.json
@@ -1,7 +1,6 @@
 {
     "comments": {
-        "lineComment": "//",
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "#"
     },
     "brackets": [
         ["{", "}"],

--- a/syntaxes/rust.json
+++ b/syntaxes/rust.json
@@ -92,7 +92,7 @@
             "name": "variable.other.meta.source.rust"
         },
         {
-            "match": "\\b(const|crate|enum|extern|fn|impl|let|macro|mod|move|mut|pub|ref|static|struct|trait|type|unsafe|union|use|where)\\b",
+            "match": "\\b(const|crate|enum|extern|impl|let|macro|mod|move|mut|pub|ref|static|struct|trait|type|unsafe|union|use|where)\\b",
             "name": "keyword.other.source.rust"
         },
         {


### PR DESCRIPTION
The `fn` keyword was present in two regexes:

```
\b(const|crate|enum|extern|fn|...)\b
```

```
\b(fn)\s+([a-zA-Z_][a-zA-Z0-9_]*)\b
```

`vscode` matches `fn` with the first regex, which prevents the second regex from matching and the function name is not highlighted. Not sure if this has always been the case, or if `vscode` has changed the order of matching recently.

Note that this can only be seen with generic functions `fn name<T>()`, because in `fn name()`, `name()` is covered by the function call regex.

This PR removes `fn` from the first regex.
It also fixes the comments in TOML, which start with `#` not `//`.